### PR TITLE
Superstructure

### DIFF
--- a/src/main/java/frc/excalib/control/limits/ContinuousSoftLimit.java
+++ b/src/main/java/frc/excalib/control/limits/ContinuousSoftLimit.java
@@ -13,22 +13,22 @@ public class ContinuousSoftLimit extends SoftLimit {
         super(minLimit, maxLimit);
     }
 
-    public double getSetPoint(double measurement, double wantedSetPoint) {
+    public double getSetpoint(double measurement, double wantedSetpoint) {
         double upperSetPoint, lowerSetPoint;
-        if (wantedSetPoint > measurement) {
-            upperSetPoint = wantedSetPoint;
+        if (wantedSetpoint > measurement) {
+            upperSetPoint = wantedSetpoint;
             while ((upperSetPoint - 2 * Math.PI) > measurement) {
                 upperSetPoint -= 2 * Math.PI;
             }
             lowerSetPoint = upperSetPoint - 2 * Math.PI;
-        } else if (wantedSetPoint < measurement) {
-            lowerSetPoint = wantedSetPoint;
+        } else if (wantedSetpoint < measurement) {
+            lowerSetPoint = wantedSetpoint;
             while ((lowerSetPoint + 2 * Math.PI) < measurement) {
                 lowerSetPoint += 2 * Math.PI;
             }
             upperSetPoint = lowerSetPoint + 2 * Math.PI;
         } else {
-            return wantedSetPoint;
+            return wantedSetpoint;
         }
         if (upperSetPoint > super.getMaxLimit()) {
             return lowerSetPoint;

--- a/src/main/java/frc/excalib/mechanisms/turret/Turret.java
+++ b/src/main/java/frc/excalib/mechanisms/turret/Turret.java
@@ -57,7 +57,7 @@ public final class Turret extends Mechanism {
      * @param wantedPosition the wanted position of the turret.
      */
     public void setPosition(Rotation2d wantedPosition) {
-        double smartSetPoint = m_rotationLimit.getSetPoint(getPosition().getRadians(), wantedPosition.getRadians());
+        double smartSetPoint = m_rotationLimit.getSetpoint(getPosition().getRadians(), wantedPosition.getRadians());
         double pid = m_anglePIDcontroller.calculate(m_POSITION_SUPPLIER.getAsDouble(), smartSetPoint);
 //        double ff =m_angleFFcontroller.getKs() * Math.signum(pid);
         super.setVoltage(pid);

--- a/src/main/java/frc/robot/subsystems/arm/ArmPosition.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmPosition.java
@@ -10,7 +10,8 @@ public enum ArmPosition {
     ALGAE2(0),
     ALGAE3(0),
     NET(0),
-    DEFAULT(0),
+    DEFAULT_WITHOUT_GAME_PIECE(0),
+    DEFAULT_WITH_GAME_PIECE(0),
     PROCESSOR(0),
     HANDOFF(0),
     INTAKE(0);

--- a/src/main/java/frc/robot/subsystems/arm/ArmPosition.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmPosition.java
@@ -14,6 +14,7 @@ public enum ArmPosition {
     DEFAULT_WITH_GAME_PIECE(0),
     PROCESSOR(0),
     HANDOFF(0),
+    EJECT_GAME_PIECE(0),
     INTAKE(0);
     private  final double angle;
     private ArmPosition(double angle) {

--- a/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
@@ -47,10 +47,10 @@ public class ArmSubsystem extends SubsystemBase {
 
         softLimit = new ContinuousSoftLimit(
                 () -> {
-                    return (-1 * (Math.acos(m_elevatorHeightSupplier.getAsDouble() / ARM_LENGTH)) - SOFTLIMIT_BUFFER);
+                    return m_elevatorHeightSupplier.getAsDouble() < ARM_LENGTH ? 0 : -Math.PI / 2;
                 },
                 () -> {
-                    return (Math.acos(m_elevatorHeightSupplier.getAsDouble() / ARM_LENGTH) + SOFTLIMIT_BUFFER);
+                    return m_elevatorHeightSupplier.getAsDouble() < ARM_LENGTH ? Math.PI : Math.PI * 1.5;
                 }
         );
 

--- a/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
@@ -33,7 +33,7 @@ public class ArmSubsystem extends SubsystemBase {
 
 
     public ArmSubsystem() {
-        m_currentState = ArmPosition.DEFAULT;
+        m_currentState = ArmPosition.DEFAULT_WITHOUT_GAME_PIECE;
         m_angleMotor = new TalonFXMotor(ANGLE_MOTOR_ID);
         m_canCoder = new CANcoder(CAN_CODER_ID);
         m_angleSupplier = () -> m_canCoder.getPosition().getValueAsDouble() * ROTATIONS_TO_RAD;

--- a/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java
@@ -38,7 +38,7 @@ public class ArmSubsystem extends SubsystemBase {
         m_canCoder = new CANcoder(CAN_CODER_ID);
         m_angleSupplier = () -> m_canCoder.getPosition().getValueAsDouble() * ROTATIONS_TO_RAD;
         m_armMechanism = new Arm(m_angleMotor, m_angleSupplier, VELOCITY_LIMIT, new Gains(), new Mass(() -> 0, () -> 0, 0));
-        toleranceTrigger = new Trigger(() -> (Math.abs(m_angleSupplier.getAsDouble() - m_currentState.getAngle()) < TOLERANCE));
+        toleranceTrigger = new Trigger(() -> (Math.abs(m_angleSupplier.getAsDouble() - m_currentState.getAngle()) < TOLERANCE)).debounce(0.1);
         m_elevatorHeightSupplier = () -> 0;
         m_intakeOpen = () -> false;
         m_angleMotor.setInverted(DirectionState.FORWARD);
@@ -56,7 +56,7 @@ public class ArmSubsystem extends SubsystemBase {
 
         setDefaultCommand(
                 m_armMechanism.anglePositionControlCommand(
-                        ()-> softLimit.limit(m_currentState.getAngle()),
+                        () -> softLimit.getSetpoint(m_angleSupplier.getAsDouble(), m_currentState.getAngle()),
                         (__) -> toleranceTrigger.getAsBoolean(),
                         TOLERANCE,
                         this
@@ -92,7 +92,7 @@ public class ArmSubsystem extends SubsystemBase {
         m_intakeOpen = intakeOpen;
     }
 
-    public BooleanSupplier isAtPosition(){
+    public BooleanSupplier isAtPosition() {
         return toleranceTrigger;
     }
 }

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorStates.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorStates.java
@@ -13,8 +13,8 @@ public enum ElevatorStates {
     PRE_HANDOFF(0),
     NET(0),
     PROCESSOR(0),
-    DEFAULT(0);
-
+    DEFAULT_WITH_GAME_PIECE(0),
+    DEFAULT_WITHOUT_GAME_PIECE(0);
 
     private final double height;
     private ElevatorStates(double height){

--- a/src/main/java/frc/robot/subsystems/elevator/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/elevator/ElevatorSubsystem.java
@@ -43,7 +43,7 @@ public class ElevatorSubsystem extends SubsystemBase {
         setDefaultCommand(m_linearExtension.extendCommand(() -> softLimit.limit(m_currentState.getHeight()), this));
 
         atPositionTrigger = new Trigger(
-                ()-> (Math.abs(m_currentState.getHeight() - m_elevatorHeight.getAsDouble()) < TOLERANCE));
+                ()-> (Math.abs(m_currentState.getHeight() - m_elevatorHeight.getAsDouble()) < TOLERANCE)).debounce(0.1);
 
         softLimit = new ContinuousSoftLimit(
                 () -> MAX_ELEVATOR_HIGHT,

--- a/src/main/java/frc/robot/subsystems/gripper/Gripper.java
+++ b/src/main/java/frc/robot/subsystems/gripper/Gripper.java
@@ -25,8 +25,8 @@ public class Gripper extends SubsystemBase {
                 MAX_JERK,
                 new Gains()
         );
-        m_hasCoralTrigger = new Trigger(() -> HAS_CORAL_CURRENT < m_gripperWheels.logCurrent());
-        m_hasAlgaeTrigger = new Trigger(() -> HAS_CORAL_CURRENT < m_gripperWheels.logCurrent());
+        m_hasCoralTrigger = new Trigger(() -> HAS_CORAL_CURRENT < m_gripperWheels.logCurrent()).debounce(0.1);
+        m_hasAlgaeTrigger = new Trigger(() -> HAS_CORAL_CURRENT < m_gripperWheels.logCurrent()).debounce(0.1);
     }
 
     public Command releaseCoral() {

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -6,7 +6,6 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
-import frc.excalib.commands.MapCommand;
 import frc.excalib.control.gains.Gains;
 import frc.excalib.control.limits.SoftLimit;
 import frc.excalib.control.math.physics.Mass;
@@ -39,7 +38,7 @@ public class Intake extends SubsystemBase {
     public Intake(IntakeState initialState) {
 
         m_currentState = initialState;
-        m_defaultState = IntakeState.STOW;
+        m_defaultState = IntakeState.DEFAULT;
         m_armMotor = new TalonFXMotor(ARM_MOTOR_ID);
         m_rollersMotor = new TalonFXMotor(ROLLERS_MOTOR_ID);
         TalonFXMotor m_centralizerMotor = new TalonFXMotor(CENTERLIZER_MOTOR_ID);
@@ -51,9 +50,9 @@ public class Intake extends SubsystemBase {
         m_rollers = new Mechanism(m_rollersMotor);
 
         m_atPosition = new Trigger(
-                () -> Math.abs(m_angleSupplier.getAsDouble() - m_currentState.intakeAngle) < TOLERANCE);
+                () -> Math.abs(m_angleSupplier.getAsDouble() - m_currentState.intakeAngle) < TOLERANCE).debounce(0.1);
 
-        intakeOpen = new Trigger(() -> (m_atPosition.getAsBoolean() && (m_currentState == IntakeState.FLOOR_INTAKE)));
+        intakeOpen = new Trigger(() -> (m_atPosition.getAsBoolean() && (m_currentState == IntakeState.FLOOR_INTAKE))).debounce(0.1);
         m_arm = new Arm(
                 m_armMotor,
                 m_angleSupplier,
@@ -65,7 +64,7 @@ public class Intake extends SubsystemBase {
 
         );
 
-        hasCoral = new Trigger(() -> (true));
+        hasCoral = new Trigger(() -> (true)).debounce(0.1);
     }
 
     public Command defaultCommand() {

--- a/src/main/java/frc/robot/subsystems/intake/IntakeState.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeState.java
@@ -2,7 +2,7 @@ package frc.robot.subsystems.intake;
 
 public enum IntakeState {
     FLOOR_INTAKE(0,0,0),
-    STOW(0,0,0),
+    DEFAULT(0,0,0),
     HANDOFF(0,0,0),
     L1_SCORE(0, 0, 0),
     GET_CORAL_BACK_FROM_ARM(0, 0, 0),

--- a/src/main/java/frc/robot/superstructure/Constants.java
+++ b/src/main/java/frc/robot/superstructure/Constants.java
@@ -1,5 +1,6 @@
 package frc.robot.superstructure;
 
 public class Constants {
-    public static final double L1_SCORE_VOLTAGE = 10;
+    public static final double L1_SCORE_VOLTAGE = 0;
+    public static final double AT_POSITION_DEBOUNCE = 0;
 }

--- a/src/main/java/frc/robot/superstructure/RobotStates.java
+++ b/src/main/java/frc/robot/superstructure/RobotStates.java
@@ -20,14 +20,15 @@ public enum RobotStates {
 
 
     // ------ INTAKE ------
-    L1(ArmPosition.DEFAULT, ElevatorStates.DEFAULT, IntakeState.L1_SCORE),
+    L1(ArmPosition.DEFAULT_WITH_GAME_PIECE, ElevatorStates.DEFAULT_WITH_GAME_PIECE, IntakeState.L1_SCORE),
     L2(ArmPosition.L2, ElevatorStates.L2, IntakeState.STOW),
-    FLOOR_INTAKE(ArmPosition.DEFAULT, ElevatorStates.DEFAULT, IntakeState.FLOOR_INTAKE),
-    EJECT_CORAL(ArmPosition.DEFAULT, ElevatorStates.DEFAULT, IntakeState.EJECT_CORAL),
+    FLOOR_INTAKE(ArmPosition.DEFAULT_WITHOUT_GAME_PIECE, ElevatorStates.DEFAULT_WITHOUT_GAME_PIECE, IntakeState.FLOOR_INTAKE),
+    EJECT_CORAL(ArmPosition.DEFAULT_WITH_GAME_PIECE, ElevatorStates.DEFAULT_WITH_GAME_PIECE, IntakeState.EJECT_CORAL),
 
 
     // ------ GENERAL ------
-    DEFAULT(ArmPosition.DEFAULT, ElevatorStates.DEFAULT, IntakeState.STOW),
+    DEFAULT_WITH_GAME_PIECE(ArmPosition.DEFAULT_WITH_GAME_PIECE, ElevatorStates.DEFAULT_WITH_GAME_PIECE, IntakeState.STOW),
+    DEFAULT_WITHOUT_GAME_PIECE(ArmPosition.DEFAULT_WITHOUT_GAME_PIECE, ElevatorStates.DEFAULT_WITHOUT_GAME_PIECE, IntakeState.STOW),
     PREHANDOFF(ArmPosition.HANDOFF, ElevatorStates.PRE_HANDOFF , IntakeState.HANDOFF),
     HANDOFF(ArmPosition.HANDOFF, ElevatorStates.HANDOFF, IntakeState.HANDOFF);
 

--- a/src/main/java/frc/robot/superstructure/RobotStates.java
+++ b/src/main/java/frc/robot/superstructure/RobotStates.java
@@ -6,29 +6,30 @@ import frc.robot.subsystems.intake.IntakeState;
 
 public enum RobotStates {
     // ------ HIGH REEF CORAL SCORE ------
-    L2_FOLLOWTHROUGH(ArmPosition.L2_FOLLOWTHROUGH, ElevatorStates.L2_FOLLOWTHROUGH, IntakeState.STOW),
-    L3(ArmPosition.L3, ElevatorStates.L3, IntakeState.STOW),
-    L3_FOLLOWTHROUGH(ArmPosition.L3_FOLLOWTHROUGH, ElevatorStates.L3_FOLLOWTHROUGH, IntakeState.STOW),
-    L4(ArmPosition.L4, ElevatorStates.L4, IntakeState.STOW),
-    L4_FOLLOWTHROUGH(ArmPosition.L4_FOLLOWTHROUGH, ElevatorStates.L4_FOLLOWTHROUGH, IntakeState.STOW),
+    L2_FOLLOWTHROUGH(ArmPosition.L2_FOLLOWTHROUGH, ElevatorStates.L2_FOLLOWTHROUGH, IntakeState.DEFAULT),
+    L3(ArmPosition.L3, ElevatorStates.L3, IntakeState.DEFAULT),
+    L3_FOLLOWTHROUGH(ArmPosition.L3_FOLLOWTHROUGH, ElevatorStates.L3_FOLLOWTHROUGH, IntakeState.DEFAULT),
+    L4(ArmPosition.L4, ElevatorStates.L4, IntakeState.DEFAULT),
+    L4_FOLLOWTHROUGH(ArmPosition.L4_FOLLOWTHROUGH, ElevatorStates.L4_FOLLOWTHROUGH, IntakeState.DEFAULT),
 
     // ------ ALGAE REMOVAL & SCORE ------
-    ALGAE2(ArmPosition.ALGAE2, ElevatorStates.ALGAE2, IntakeState.STOW),
-    ALGAE3(ArmPosition.ALGAE3, ElevatorStates.ALGAE3, IntakeState.STOW),
-    NET(ArmPosition.NET, ElevatorStates.NET, IntakeState.STOW),
-    PROCESSOR(ArmPosition.PROCESSOR, ElevatorStates.PROCESSOR, IntakeState.STOW),
+    ALGAE2(ArmPosition.ALGAE2, ElevatorStates.ALGAE2, IntakeState.DEFAULT),
+    ALGAE3(ArmPosition.ALGAE3, ElevatorStates.ALGAE3, IntakeState.DEFAULT),
+    NET(ArmPosition.NET, ElevatorStates.NET, IntakeState.DEFAULT),
+    PROCESSOR(ArmPosition.PROCESSOR, ElevatorStates.PROCESSOR, IntakeState.DEFAULT),
 
 
     // ------ INTAKE ------
     L1(ArmPosition.DEFAULT_WITH_GAME_PIECE, ElevatorStates.DEFAULT_WITH_GAME_PIECE, IntakeState.L1_SCORE),
-    L2(ArmPosition.L2, ElevatorStates.L2, IntakeState.STOW),
+    L2(ArmPosition.L2, ElevatorStates.L2, IntakeState.DEFAULT),
     FLOOR_INTAKE(ArmPosition.DEFAULT_WITHOUT_GAME_PIECE, ElevatorStates.DEFAULT_WITHOUT_GAME_PIECE, IntakeState.FLOOR_INTAKE),
-    EJECT_CORAL(ArmPosition.DEFAULT_WITH_GAME_PIECE, ElevatorStates.DEFAULT_WITH_GAME_PIECE, IntakeState.EJECT_CORAL),
+    EJECT_CORAL_FROM_INTAKE(ArmPosition.DEFAULT_WITH_GAME_PIECE, ElevatorStates.DEFAULT_WITH_GAME_PIECE, IntakeState.EJECT_CORAL),
+    EJECT_GAME_PIECE_FROM_GRIPPER(ArmPosition.EJECT_GAME_PIECE, ElevatorStates.DEFAULT_WITH_GAME_PIECE, IntakeState.DEFAULT),
 
 
     // ------ GENERAL ------
-    DEFAULT_WITH_GAME_PIECE(ArmPosition.DEFAULT_WITH_GAME_PIECE, ElevatorStates.DEFAULT_WITH_GAME_PIECE, IntakeState.STOW),
-    DEFAULT_WITHOUT_GAME_PIECE(ArmPosition.DEFAULT_WITHOUT_GAME_PIECE, ElevatorStates.DEFAULT_WITHOUT_GAME_PIECE, IntakeState.STOW),
+    DEFAULT_WITH_GAME_PIECE(ArmPosition.DEFAULT_WITH_GAME_PIECE, ElevatorStates.DEFAULT_WITH_GAME_PIECE, IntakeState.DEFAULT),
+    DEFAULT_WITHOUT_GAME_PIECE(ArmPosition.DEFAULT_WITHOUT_GAME_PIECE, ElevatorStates.DEFAULT_WITHOUT_GAME_PIECE, IntakeState.DEFAULT),
     PREHANDOFF(ArmPosition.HANDOFF, ElevatorStates.PRE_HANDOFF , IntakeState.HANDOFF),
     HANDOFF(ArmPosition.HANDOFF, ElevatorStates.HANDOFF, IntakeState.HANDOFF);
 

--- a/src/main/java/frc/robot/superstructure/Superstructure.java
+++ b/src/main/java/frc/robot/superstructure/Superstructure.java
@@ -10,6 +10,7 @@ import frc.robot.subsystems.intake.IntakeState;
 
 import java.util.HashMap;
 
+import static frc.robot.superstructure.Constants.AT_POSITION_DEBOUNCE;
 import static frc.robot.superstructure.Constants.L1_SCORE_VOLTAGE;
 
 public class Superstructure {
@@ -31,7 +32,7 @@ public class Superstructure {
         atPositionTrigger = new Trigger(
                 () -> elevatorSubsystem.atPositionTrigger.getAsBoolean()
                         && armSubsystem.isAtPosition().getAsBoolean()
-                        && intakeSubsystem.isAtPosition().getAsBoolean()).debounce(0.1);
+                        && intakeSubsystem.isAtPosition().getAsBoolean()).debounce(AT_POSITION_DEBOUNCE);
         gripperSubsystem = new Gripper();
         elevatorSubsystem.setArmAngle(armSubsystem.getAngleSupplier());
         armSubsystem.setElevatorHeightSupplier(elevatorSubsystem.getElevatorHeight());
@@ -46,7 +47,7 @@ public class Superstructure {
 
     public Command setCurrentStateCommand(RobotStates state) {
         return new InstantCommand(() -> this.currentState = state);
-//        new WaitUntilCommand(atPositionTrigger); // TODO: sequsudghsfhntial command
+//        new WaitUntilCommand(atPositionTrigger); // TODO: sequntinal command
     }
 
     public void returnToDefaultState() {
@@ -69,7 +70,6 @@ public class Superstructure {
             }
         }
     }
-
 
     public Command reefScoreCommand(RobotStates scoreState) {
         return new ConditionalCommand(
@@ -118,7 +118,7 @@ public class Superstructure {
                 intakeSubsystem.hasCoral.and(gripperSubsystem.m_hasAlgaeTrigger.negate()).and(gripperSubsystem.m_hasCoralTrigger.negate())).withName("handoff Command"); //TODO isn't it supposed to be or() instead of and()?
     }
 
-    public Command ejectCommand() { //TODO (needs Yehuda's approval) make the command supercycel friendly
+    public Command ejectCommand() { //TODO (needs Yehuda's approval) make the command supercycle friendly
         return new ConditionalCommand(
                 new SequentialCommandGroup(
                         setCurrentStateCommand(RobotStates.EJECT_CORAL_FROM_INTAKE).until(atPositionTrigger.and(intakeSubsystem.hasCoral.negate())),
@@ -182,7 +182,9 @@ public class Superstructure {
 
                 (gripperSubsystem.m_hasAlgaeTrigger.or(gripperSubsystem.m_hasCoralTrigger)).negate()).withName("Algae Intake Command");
 
-    }   public Command algaeReleaseCommand() {
+    }
+
+    public Command algaeReleaseCommand() {
         return new ConditionalCommand(
                 new SequentialCommandGroup(
                         gripperSubsystem.releaseAlgae().until(gripperSubsystem.m_hasAlgaeTrigger.negate()),
@@ -193,8 +195,6 @@ public class Superstructure {
                 (gripperSubsystem.m_hasAlgaeTrigger)).withName("Algae Intake Command");
 
     }
-
-
 }
 
 


### PR DESCRIPTION
This pull request introduces several changes across multiple subsystems to improve naming consistency, enhance functionality, and refine triggers for better responsiveness. The most significant updates include renaming methods and states for clarity, adding debounce functionality to triggers, and expanding the `RobotStates` and `ArmPosition` enums to support new operational modes.

### Naming Consistency Improvements:
* Renamed `getSetPoint` to `getSetpoint` in `ContinuousSoftLimit` and updated all references to this method across subsystems for consistent naming. (`src/main/java/frc/excalib/control/limits/ContinuousSoftLimit.java`, [[1]](diffhunk://#diff-2c8c4fad98d7207dec68bf9f0333149a7ed2c29128f5b3d772eecf4360aa64afL16-R31); `src/main/java/frc/excalib/mechanisms/turret/Turret.java`, [[2]](diffhunk://#diff-de5815ba44f25edc952139f11bfaeb6521d27fbd14b80bf3b0c35853dbec1e77L60-R60); `src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java`, [[3]](diffhunk://#diff-3deebf9077331cec33a2d1ab9c2ea0e33e8df1f5ea2e6dd58407d78f6f6e65d2L59-R59)

### Enum Expansions:
* Added new states to `ArmPosition`, including `DEFAULT_WITHOUT_GAME_PIECE`, `DEFAULT_WITH_GAME_PIECE`, and `EJECT_GAME_PIECE`, to accommodate game piece-specific operations. (`src/main/java/frc/robot/subsystems/arm/ArmPosition.java`, [src/main/java/frc/robot/subsystems/arm/ArmPosition.javaL13-R17](diffhunk://#diff-14b6d9d94f54959870f881990bf0066dba242f1afc53d415b6093399c79e4e31L13-R17))
* Expanded `ElevatorStates` with `DEFAULT_WITH_GAME_PIECE` and `DEFAULT_WITHOUT_GAME_PIECE` for better differentiation between operational contexts. (`src/main/java/frc/robot/subsystems/elevator/ElevatorStates.java`, [src/main/java/frc/robot/subsystems/elevator/ElevatorStates.javaL16-R17](diffhunk://#diff-fc1529d81c9001ef4781a81cdd23caacdd831fb66edbe5d1fd2f5bae85247897L16-R17))
* Updated `RobotStates` to replace `DEFAULT` and `STOW` with `DEFAULT_WITH_GAME_PIECE` and `DEFAULT_WITHOUT_GAME_PIECE`, along with new eject states for coral and game pieces. (`src/main/java/frc/robot/superstructure/RobotStates.java`, [src/main/java/frc/robot/superstructure/RobotStates.javaL9-R32](diffhunk://#diff-fefa815dc32ce07f50c10a552bc88dfa3fec402214a955883ec71d2a7b92daabL9-R32))

### Trigger Enhancements:
* Added debounce functionality to various triggers across subsystems to reduce noise and improve reliability. Examples include tolerance triggers in `ArmSubsystem`, `ElevatorSubsystem`, and `Gripper`. (`src/main/java/frc/robot/subsystems/arm/ArmSubsystem.java`, [[1]](diffhunk://#diff-3deebf9077331cec33a2d1ab9c2ea0e33e8df1f5ea2e6dd58407d78f6f6e65d2L36-R41); `src/main/java/frc/robot/subsystems/elevator/ElevatorSubsystem.java`, [[2]](diffhunk://#diff-218598aef3b89df66f1cb6d6c41ea8e628741d662e46fbfa5ed3bc5c02a86878L46-R46); `src/main/java/frc/robot/subsystems/gripper/Gripper.java`, [[3]](diffhunk://#diff-806e57214094bfffc991d4898ffe2c6d591e20db14dac8d58f02e8e377f370c5L28-R29)

### Intake Subsystem Updates:
* Renamed `STOW` state to `DEFAULT` in `IntakeState` and updated references across the subsystem. (`src/main/java/frc/robot/subsystems/intake/IntakeState.java`, [[1]](diffhunk://#diff-366e1a60e91e92d539e809fa361d1ecf9ca2c4336b50dc6d113ad9ee645a5f00L5-R5); `src/main/java/frc/robot/subsystems/intake/Intake.java`, [[2]](diffhunk://#diff-1a758387a0680867462338c932cffc488859f29f631a09edd0c6471f5c0841c0L42-R41)
* Added debounce functionality to triggers in the `Intake` subsystem for better responsiveness. (`src/main/java/frc/robot/subsystems/intake/Intake.java`, [[1]](diffhunk://#diff-1a758387a0680867462338c932cffc488859f29f631a09edd0c6471f5c0841c0L54-R55) [[2]](diffhunk://#diff-1a758387a0680867462338c932cffc488859f29f631a09edd0c6471f5c0841c0L68-R67)

### Superstructure Enhancements:
* Updated default states and added conditional commands for ejecting coral and game pieces, making the system more adaptable to different scenarios. (`src/main/java/frc/robot/superstructure/Superstructure.java`, [[1]](diffhunk://#diff-c7e21fef238bbb171d8648b98bc931d377e1a3ec9366817d76bc149ab282a06aL26-R34) [[2]](diffhunk://#diff-c7e21fef238bbb171d8648b98bc931d377e1a3ec9366817d76bc149ab282a06aL119-R135)
* Refined scoring commands to include new states and improved logic for handling game pieces. (`src/main/java/frc/robot/superstructure/Superstructure.java`, [[1]](diffhunk://#diff-c7e21fef238bbb171d8648b98bc931d377e1a3ec9366817d76bc149ab282a06aL84-R109) [[2]](diffhunk://#diff-c7e21fef238bbb171d8648b98bc931d377e1a3ec9366817d76bc149ab282a06aL138-R147)